### PR TITLE
Potential fix for code scanning alert no. 134: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: code-formatter
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/MattWhite-personal/dns-iac/security/code-scanning/134](https://github.com/MattWhite-personal/dns-iac/security/code-scanning/134)

The issue can be fixed by adding a `permissions` block to the workflow file. Since this workflow appears to format code and may interact with pull requests, the `contents: read` and `pull-requests: write` permissions are sufficient. These permissions allow the workflow to read the repository's contents and update pull requests as needed.

To implement the fix:
- Add a `permissions` block at the root of the workflow file, directly under the `name` field. This block will apply to all jobs in the workflow.
- Set `contents` to `read` and `pull-requests` to `write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
