### PR TITLE
pin all the actions to sha

### DIFF
--- a/.github/workflows/tf-drift.yml
+++ b/.github/workflows/tf-drift.yml
@@ -41,11 +41,11 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Install the latest version of the Terraform CLI
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
 
@@ -54,7 +54,7 @@ jobs:
         run: terraform init
       # Login to Azure CLI to support temporary runner IP allow-list
       - name: Setup Azure CLI
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -141,7 +141,7 @@ jobs:
 
       # Save plan to artifacts
       - name: Publish Terraform Plan
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: tfplan
           path: tfplan
@@ -197,7 +197,7 @@ jobs:
       # If changes are detected, create a new issue
       - name: Publish Drift Report
         if: steps.tf-plan.outputs.exitcode == 2
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
         with:
@@ -257,7 +257,7 @@ jobs:
       # If changes aren't detected, close any open drift issues
       - name: Publish Drift Report
         if: steps.tf-plan.outputs.exitcode == 0
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -287,7 +287,7 @@ jobs:
       # Create an issue when the job fails for reasons OTHER THAN tf-plan failing
       - name: Create Issue on Failure (non-tf-plan)
         if: ${{ failure() && steps.tf-plan.conclusion != 'failure' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -358,3 +358,4 @@ jobs:
       - name: Error on Failure
         if: steps.tf-plan.outputs.exitcode == 2
         run: exit 1
+

--- a/.github/workflows/tf-plan-apply.yml
+++ b/.github/workflows/tf-plan-apply.yml
@@ -43,11 +43,11 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Install the latest version of the Terraform CLI
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3.1.2
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
 
@@ -57,7 +57,7 @@ jobs:
 
       # Login to Azure CLI to support temporary runner IP allow-list
       - name: Setup Azure CLI
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -218,3 +218,4 @@ jobs:
             echo "Storage account: $STORAGE_ACCOUNT, Resource group: $RESOURCE_GROUP"
             az storage account network-rule remove --resource-group $RESOURCE_GROUP  --account-name $STORAGE_ACCOUNT --ip-address ${{ steps.get-runner-ip.outputs.runner_ip }} > /dev/null
           done
+

--- a/.github/workflows/tf-unit-tests.yml
+++ b/.github/workflows/tf-unit-tests.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v6.0.1
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3.1.2
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
@@ -39,7 +39,7 @@ jobs:
     # Perform a security scan of the terraform code using checkov
     - name: Run Checkov action
       id: checkov
-      uses: bridgecrewio/checkov-action@v12.3075.0
+      uses: bridgecrewio/checkov-action@02a4c5d6a02367e5ea493c34c26b094302fd3f61 # v12.3075.0
       with: 
         framework: terraform
         # This will add both a CLI output to the console and create a results.sarif file
@@ -50,7 +50,8 @@ jobs:
      # Upload results to GitHub Advanced Security
     - name: Upload SARIF file
       if: success() || failure()
-      uses: github/codeql-action/upload-sarif@v4.31.9
+      uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 #v4.31.9
       with:
         sarif_file: results.sarif
         category: checkov
+


### PR DESCRIPTION
Update all github actions workflows to use a pinned sha hash rather than semver